### PR TITLE
chore(*): fall cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.2.0
+- adds the `activate`, `deactivate` and `activation` keywords to the xù grammar
+- modernizes the dependency update process
+- updates development dependencies to latest
+- updates repository.url and categories fields to Microsoft's latest advice
+
 ## 1.1.0
 - adds the `wordwrapentities` and `wordwrapboxes` options to the xù and MsGenny
   grammars

--- a/package.json
+++ b/package.json
@@ -1,112 +1,122 @@
 {
-    "name": "vscode-mscgen",
-    "displayName": "MscGen",
-    "description": "Syntax highlighting and snippets for MscGen and two similar sequence chart languages",
-    "version": "1.1.0",
-    "publisher": "mscgenjs",
-    "icon": "assets/icon.png",
-    "galleryBanner": {
-        "color": "#ffffff",
-        "theme": "light"
-    },
-    "engines": {
-        "vscode": "^1.5.0"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/mscgenjs/vscode-mscgen"
-    },
-    "homepage": "https://github.com/mscgenjs/vscode-mscgen",
-    "bugs": {
-        "url": "https://github.com/mscgenjs/vscode-mscgen/issues"
-    },
-    "license": "GPL-3.0",
-    "categories": [
-        "Languages",
-        "Snippets"
-    ],
-    "keywords": [
-        "MscGen",
-        "Xù",
-        "MsGenny"
-    ],
-    "contributes": {
-        "languages": [
-            {
-                "id": "mscgen",
-                "aliases": [
-                    "MscGen",
-                    "mscgen"
-                ],
-                "extensions": [
-                    ".msc",
-                    ".mscgen",
-                    ".mscin"
-                ],
-                "configuration": "./language-configuration.mscgen.json"
-            },
-            {
-                "id": "msgenny",
-                "aliases": [
-                    "MsGenny",
-                    "msgenny"
-                ],
-                "extensions": [
-                    ".msgenny"
-                ],
-                "configuration": "./language-configuration.msgenny.json"
-            },
-            {
-                "id": "xu",
-                "aliases": [
-                    "Xu",
-                    "Xù",
-                    "xu"
-                ],
-                "extensions": [
-                    ".xu"
-                ],
-                "configuration": "./language-configuration.xu.json"
-            }
+  "name": "vscode-mscgen",
+  "displayName": "MscGen",
+  "description": "Syntax highlighting and snippets for MscGen and two similar sequence chart languages",
+  "version": "1.1.0",
+  "publisher": "mscgenjs",
+  "icon": "assets/icon.png",
+  "galleryBanner": {
+    "color": "#ffffff",
+    "theme": "light"
+  },
+  "engines": {
+    "vscode": "^1.5.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mscgenjs/vscode-mscgen"
+  },
+  "homepage": "https://github.com/mscgenjs/vscode-mscgen",
+  "bugs": {
+    "url": "https://github.com/mscgenjs/vscode-mscgen/issues"
+  },
+  "license": "GPL-3.0",
+  "categories": [
+    "Programming Languages",
+    "Snippets"
+  ],
+  "keywords": [
+    "MscGen",
+    "Xù",
+    "MsGenny"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "mscgen",
+        "aliases": [
+          "MscGen",
+          "mscgen"
         ],
-        "grammars": [
-            {
-                "language": "mscgen",
-                "scopeName": "source.mscgen",
-                "path": "./syntaxes/mscgen.tmLanguage.json"
-            },
-            {
-                "language": "msgenny",
-                "scopeName": "source.msgenny",
-                "path": "./syntaxes/msgenny.tmLanguage.json"
-            },
-            {
-                "language": "xu",
-                "scopeName": "source.xu",
-                "path": "./syntaxes/xu.tmLanguage.json"
-            }
+        "extensions": [
+          ".msc",
+          ".mscgen",
+          ".mscin"
         ],
-        "snippets": [
-            {
-                "language": "mscgen",
-                "path": "./snippets/mscgen.json"
-            },
-            {
-                "language": "xu",
-                "path": "./snippets/xu.json"
-            },
-            {
-                "language": "msgenny",
-                "path": "./snippets/msgenny.json"
-            }
-        ]
-    },
-    "devDependencies": {
-        "tap-spec": "4.1.1",
-        "tape": "4.7.0",
-        "vscode-textmate": "3.1.5"
-    },
-    "scripts": {
-        "test": "tape test/*.spec.js | tap-spec"
-    }
+        "configuration": "./language-configuration.mscgen.json"
+      },
+      {
+        "id": "msgenny",
+        "aliases": [
+          "MsGenny",
+          "msgenny"
+        ],
+        "extensions": [
+          ".msgenny"
+        ],
+        "configuration": "./language-configuration.msgenny.json"
+      },
+      {
+        "id": "xu",
+        "aliases": [
+          "Xu",
+          "Xù",
+          "xu"
+        ],
+        "extensions": [
+          ".xu"
+        ],
+        "configuration": "./language-configuration.xu.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "mscgen",
+        "scopeName": "source.mscgen",
+        "path": "./syntaxes/mscgen.tmLanguage.json"
+      },
+      {
+        "language": "msgenny",
+        "scopeName": "source.msgenny",
+        "path": "./syntaxes/msgenny.tmLanguage.json"
+      },
+      {
+        "language": "xu",
+        "scopeName": "source.xu",
+        "path": "./syntaxes/xu.tmLanguage.json"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "mscgen",
+        "path": "./snippets/mscgen.json"
+      },
+      {
+        "language": "xu",
+        "path": "./snippets/xu.json"
+      },
+      {
+        "language": "msgenny",
+        "path": "./snippets/msgenny.json"
+      }
+    ]
+  },
+  "devDependencies": {
+    "npm-run-all": "4.1.3",
+    "tap-spec": "5.0.0",
+    "tape": "4.9.1",
+    "upem": "1.0.1",
+    "vscode-textmate": "3.3.3"
+  },
+  "upem": {
+    "donotup": [
+      "vscode-textmate"
+    ]
+  },
+  "scripts": {
+    "test": "tape test/*.spec.js | tap-spec",
+    "update-dependencies": "npm-run-all upem:update upem:install test",
+    "upem:update": "npm outdated --json | upem",
+    "upem:install": "npm install"
+  }
 }

--- a/syntaxes/xu.tmLanguage.json
+++ b/syntaxes/xu.tmLanguage.json
@@ -218,7 +218,7 @@
       ]
     },
     "attributename": {
-      "match": "\\b(label|idurl|id|url|linecolor|linecolour|textcolor|textcolour|textbgcolor|textbgcolour|arclinecolor|arclinecolour|arctextcolor|arctextcolour|arctextbgcolor|arctextbgcolour|arcskip|title)\\b",
+      "match": "\\b(label|idurl|id|url|linecolor|linecolour|textcolor|textcolour|textbgcolor|textbgcolour|arclinecolor|arclinecolour|arctextcolor|arctextcolour|arctextbgcolor|arctextbgcolour|arcskip|title|activate|deactivate|activation)\\b",
       "name": "keyword.attribute.xu"
     },
     "attributevalue": {

--- a/test/mscgen.spec.js
+++ b/test/mscgen.spec.js
@@ -1,7 +1,7 @@
 const test = require("tape");
 const fixtures = require("./mscgen.fixtures.json");
 
-const Registry = new require("vscode-textmate").Registry;
+const Registry = require("vscode-textmate").Registry;
 const registry = new Registry();
 const grammar = registry.loadGrammarFromPathSync("syntaxes/mscgen.tmLanguage.json");
 

--- a/test/xu.spec.js
+++ b/test/xu.spec.js
@@ -1,7 +1,7 @@
 const test = require("tape");
 
 
-const Registry = new require("vscode-textmate").Registry;
+const Registry = require("vscode-textmate").Registry;
 const registry = new Registry();
 const grammar = registry.loadGrammarFromPathSync("syntaxes/xu.tmLanguage.json");
 


### PR DESCRIPTION
- automate updating dependencies
- update dependencies (dev: tape, tap-spec, vscode-textmate)
- update repository.url and categories fields to Microsoft's latest advice
- adds `activate`, `deactivate` and `activation` keywords to the Xù grammar
- makes vscode-mscgen ready for publishing